### PR TITLE
Correct a repository name in a spec

### DIFF
--- a/spec/features/issue_index_spec.rb
+++ b/spec/features/issue_index_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Issue Index Page' do
 
   before do
     @issue_without_pr = create(:issue, subject: 'Issue without PR')
-    issue_with_pr.create_pull_request!(url: 'https://github.com/octocat/spoon-fork/pulls/1')
+    issue_with_pr.create_pull_request!(url: 'https://github.com/octocat/Spoon-Knife/pulls/1')
     visit issues_path
   end
 


### PR DESCRIPTION
https://github.com/octocat/spoon-fork/ doesn't exist and I should have use https://github.com/octocat/Spoon-Knife.

This doesn't affect the result of specs, but I'd like to amend it 🙈 