### PR TITLE
Fetch changesets from Github

### DIFF
--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -5,8 +5,9 @@ require_dependency 'repository/git'
 class Repository::Github < ::Repository::Git
   validates_presence_of :url
 
-  delegate :bare_clone, to: :scm
+  delegate :bare_clone, :fetch_remote, to: :scm
   after_create :bare_clone
+  after_update :fetch_remote
 
   def self.scm_adapter_class
     RedmineGithub::Scm::Adapters::GithubAdapter
@@ -14,5 +15,12 @@ class Repository::Github < ::Repository::Git
 
   def self.scm_name
     'Github'
+  end
+
+  # Will be executed from background jobs as:
+  # rails runner 'Repository.fetch_changesets'
+  def fetch_changesets
+    fetch_remote
+    super
   end
 end

--- a/lib/redmine_github/scm/adapters/github_adapter.rb
+++ b/lib/redmine_github/scm/adapters/github_adapter.rb
@@ -34,5 +34,14 @@ module RedmineGithub::Scm::Adapters
       cmd_args = %W[clone --bare #{url_with_token} #{root_url}]
       git_cmd(cmd_args)
     end
+
+    def fetch_remote
+      return unless Dir.exist?(root_url)
+
+      cmd_args = %w[fetch origin]
+      cmd_args += %w[+refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/*]
+      cmd_args += %w[--prune --prune-tags]
+      git_cmd(cmd_args)
+    end
   end
 end

--- a/spec/lib/redmine/scm/adapters/github_adapter_spec.rb
+++ b/spec/lib/redmine/scm/adapters/github_adapter_spec.rb
@@ -3,51 +3,72 @@
 require File.expand_path('../../../../rails_helper', __dir__)
 
 RSpec.describe RedmineGithub::Scm::Adapters::GithubAdapter do
-  subject { RedmineGithub::Scm::Adapters::GithubAdapter.new(url, nil, login, token) }
-
+  let(:scm) { RedmineGithub::Scm::Adapters::GithubAdapter.new(url, nil, login, token) }
   let(:url) { 'https://github.com/company/repo.git' }
   let(:login) { 'user' }
   let(:token) { '1234567890' }
 
-  before do
+  before :each do
     # will not try to create directory if it does not exists
-    allow(Dir).to receive(:exists?) { true }
+    allow(Dir).to receive(:exist?) { true }
+    allow(scm).to receive(:git_cmd) { nil }
   end
 
   describe '.repositories_root_path' do
+    subject { scm.repositories_root_path }
     context 'directory exists' do
-      it { expect(subject.repositories_root_path).to eq Rails.root.join('repositories') }
+      it { is_expected.to eq Rails.root.join('repositories') }
     end
   end
 
   describe '.root_url' do
+    subject { scm.root_url }
     context 'url is provided' do
-      it { expect(subject.root_url).to eq Rails.root.join('repositories', 'company-repo') }
+      it { is_expected.to eq Rails.root.join('repositories', 'company-repo') }
     end
 
     context 'no url is provided' do
       let(:url) { nil }
 
-      it { expect(subject.root_url).to eq '' }
+      it { is_expected.to eq '' }
     end
   end
 
   describe '.url_with_token' do
+    subject { scm.url_with_token }
     context 'no login and token are provided' do
       let(:login) { nil }
       let(:token) { nil }
 
-      it { expect(subject.url_with_token).to eq url }
+      it { is_expected.to eq url }
     end
 
     context 'only login is provided' do
       let(:token) { nil }
 
-      it { expect(subject.url_with_token).to eq "https://#{login}@github.com/company/repo.git" }
+      it { is_expected.to eq "https://#{login}@github.com/company/repo.git" }
     end
 
     context 'login and token are provided' do
-      it { expect(subject.url_with_token).to eq "https://#{login}:#{token}@github.com/company/repo.git" }
+      it { is_expected.to eq "https://#{login}:#{token}@github.com/company/repo.git" }
+    end
+  end
+
+  describe '.fetch_remote' do
+    subject { scm.fetch_remote }
+    context 'root directory does not exists' do
+      before do
+        allow(Dir).to receive(:exist?) { false }
+        expect(scm).to_not receive(:git_cmd)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'root directory exists' do
+      let(:git_cmd_args) { %w[fetch origin +refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/* --prune --prune-tags] }
+      before { expect(scm).to receive(:git_cmd).with(git_cmd_args).and_return(nil) }
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
Stories:
- https://insidemine.agileware.jp/issues/17750
- https://insidemine.agileware.jp/issues/17752

Current PR just adding `git fetch` from GitHub to the original Redmine Git repository `fetch_changesets` method. After fetching, created bare repository local clone is managed as usual local Git repository. Because of this all original _getting issue from comments_ Redmine methods can be used.