### PR TITLE
Support webhook on redmine-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For given project, in \_(Settings|Repositories|New Repository) form enter:
 
 - _SCM_ - **Github**
 - _Identifier_ - uniq repository identifier
-- _URL_ - Github repository URL ([clone address](https://help.github.com/en/articles/which-remote-url-should-i-use#cloning-with-https-urls-recommended), starting with `https://` )
+- _URL_ - GitHub repository HTTPS URL ([clone address](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#about-remote-repositories), starting with `https://`)
 - _Access Token_ - [personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
 - _Webhook Secret_ - [webhook secret](https://developer.github.com/webhooks/securing/)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Redmine Github plugin
+# Redmine GitHub plugin
 
-_redmine_github_ is a Redmine plugin for connecting a local Redmine installation to a remote Github repository. The plugin allows to:
+_redmine_github_ is a Redmine plugin for connecting a local Redmine installation to a remote GitHub repository. The plugin allows to:
 
-- Syncronize remote Github repository to a local Git one - all Git-related Redmine features can be used
+- Syncronize remote GitHub repository to a local Git one - all Git-related Redmine features can be used
 - Attach pull request (PR) status icons to issues - will change in real time, when pul request status change - created, approved, merged etc.
 - Connect commit comment to issues via [Redmine commit comments keywords](<(https://www.redmine.org/projects/redmine/wiki/RedmineSettings#Referencing-issues-in-commit-messages)>)
 
@@ -52,7 +52,7 @@ After pressing _'Create'_ button, bare-clone repository will be created inside y
 
 > Note the **repository ID** in the _'Edit'_ and _'Delete'_ links - you will need this for the next step (webhook url)
 
-### 3. Connecting Github to Redmine
+### 3. Connecting GitHub to Redmine
 
 1. Go to the repository _Settings_ interface on GitHub.
 2. Under _Webhooks_ add a new webHook:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ After restart, also check if plugin is listed in the installed Redmine plugins l
 For given project, in \_(Settings|Repositories|New Repository) form enter:
 
 - _SCM_ - **Github**
-- _Identifier_ - uniq repository identifier
+- _Identifier_ - unique repository identifier
 - _URL_ - GitHub repository HTTPS URL ([clone address](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#about-remote-repositories), starting with `https://`)
 - _Access Token_ - [personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
 - _Webhook Secret_ - [webhook secret](https://developer.github.com/webhooks/securing/)

--- a/app/controllers/redmine_github/webhooks_controller.rb
+++ b/app/controllers/redmine_github/webhooks_controller.rb
@@ -2,7 +2,11 @@
 
 module RedmineGithub
   class WebhooksController < ActionController::Base
+    # verifying request by X-Hub-Signature-256 header
+    skip_forgery_protection if Redmine::VERSION::MAJOR >= 5
+
     before_action :set_repository, :verify_signature
+
     def dispatch_event
       event = request.headers['x-github-event']
       case event

--- a/app/controllers/redmine_github/webhooks_controller.rb
+++ b/app/controllers/redmine_github/webhooks_controller.rb
@@ -27,8 +27,8 @@ module RedmineGithub
 
     def verify_signature
       request.body.rewind
-      signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), @repository.webhook_secret, request.body.read)
-      head :bad_request unless Rack::Utils.secure_compare(signature, request.headers['x-hub-signature'])
+      signature = 'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), @repository.webhook_secret, request.body.read)
+      head :bad_request unless Rack::Utils.secure_compare(signature, request.headers['x-hub-signature-256'])
     end
   end
 end

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -8,6 +8,7 @@ class Repository::Github < ::Repository::Git
 
   safe_attributes 'access_token', 'webhook_secret'
   validates_presence_of :url
+  validates_presence_of :access_token
   validates_presence_of :webhook_secret
 
   delegate :bare_clone, :fetch_remote, :update_remote_url, to: :scm

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -8,6 +8,7 @@ class Repository::Github < ::Repository::Git
 
   safe_attributes 'access_token', 'webhook_secret'
   validates_presence_of :url
+  validates_presence_of :webhook_secret
 
   delegate :bare_clone, :fetch_remote, :update_remote_url, to: :scm
   after_create :bare_clone

--- a/app/views/redmine_github/_github_fields.html.erb
+++ b/app/views/redmine_github/_github_fields.html.erb
@@ -30,6 +30,7 @@
       label: l(:label_github_webhook_secret),
       size: 30,
       name: 'ignore',
+      required: true,
       value: (repository.new_record? || repository.webhook_secret.blank? ? '' : ('x' * 15)),
       onfocus: "this.value=''; this.name='repository[webhook_secret]';",
       onchange: "this.name='repository[webhook_secret]';"

--- a/app/views/redmine_github/_github_fields.html.erb
+++ b/app/views/redmine_github/_github_fields.html.erb
@@ -17,6 +17,7 @@
       label: l(:label_github_token),
       size: 30,
       name: 'ignore',
+      required: true,
       value: (repository.new_record? || repository.access_token.blank? ? '' : ('x' * 15)),
       onfocus: "this.value=''; this.name='repository[access_token]';",
       onchange: "this.name='repository[access_token]';"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  field_access_token: Access Token
   field_webhook_secret: Webhook Secret
   label_github_token: Access Token
   label_github_webhook_secret: Webhook Secret

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  field_webhook_secret: Webhook Secret
   label_github_token: Access Token
   label_github_webhook_secret: Webhook Secret
   setting_redmine_github_title: Redmine Github Settings

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,5 @@
 ja:
+  field_access_token: アクセストークン
   field_webhook_secret: Webhook Secret
   label_github_token: アクセストークン
   label_github_webhook_secret: Webhook Secret

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,5 @@
 ja:
+  field_webhook_secret: Webhook Secret
   label_github_token: アクセストークン
   label_github_webhook_secret: Webhook Secret
   setting_redmine_github_title: Redmine Github プラグイン設定

--- a/lib/redmine_github/include/repositories_controller_patch.rb
+++ b/lib/redmine_github/include/repositories_controller_patch.rb
@@ -28,7 +28,7 @@ module RedmineGithub
         use_hostname = ::Setting.plugin_redmine_github['webhook_use_hostname'].to_s
         return redmine_github_webhook_url(repository_id: @repository) unless use_hostname == '1'
         webhook_path = redmine_github_webhook_path(repository_id: @repository)
-        "https://#{::Setting.host_name}#{webhook_path}"
+        "#{::Setting.protocol}://#{::Setting.host_name}#{webhook_path}"
       end
     end
   end


### PR DESCRIPTION
This pull-request contains:

- https://github.com/agileware-jp/redmine_github/pull/48/commits/6095c09c87cba5dacaa826da6826931729ff0df6 Support Webhook on redmine-5
    - mainly fixes
- https://github.com/agileware-jp/redmine_github/pull/48/commits/f460d3b95e69cba36c0c63d48f8a42f52ae0e720 Make "webhook secret" required
    - "webhook secret" is used by verifying webhook signature, So it must be required.
- https://github.com/agileware-jp/redmine_github/pull/48/commits/70ba88ae4790cb1403777e6c78ecf6285eb34fc4 Make "access token" required
    - "access token" must be required, because it is used by fetching pull request information. I saw following :eyes: :
        - https://github.com/agileware-jp/redmine_github/blob/0cd034dda2ea503e6a05b9f2565ff2fd36d33041/lib/redmine_github/github_api/graphql.rb#L53-L57
        - https://github.com/agileware-jp/redmine_github/blob/0cd034dda2ea503e6a05b9f2565ff2fd36d33041/app/models/repository/github.rb#L44-L45
- https://github.com/agileware-jp/redmine_github/pull/48/commits/582dc687001d8c585f36436abe0443ce5ac12cb1 Respect Redmine's global "protocol" setting
- https://github.com/agileware-jp/redmine_github/pull/48/commits/d8706b782412a65a0e19a8d9b7274bdcd752d1b2 Update Webhook verification: SHA1 -> SHA256

---

Related pull-request: https://github.com/agileware-jp/redmine_github/pull/36
