### PR TITLE
Fix suppress 500 error on repository setting

### DIFF
--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -18,12 +18,7 @@ class Repository::Github < ::Repository::Git
   after_update :update_remote_url
 
   def self.human_attribute_name(attribute_key_name, *args)
-    if attribute_key_name.to_s == 'url'
-      # omit https://github.com/redmine/redmine/blob/5.0.2/app/models/repository/git.rb#L30-L31
-      superclass.superclass.__send__(__method__, attribute_key_name, *args)
-    else
-      super
-    end
+    Repository.human_attribute_name(attribute_key_name, *args)
   end
 
   def self.scm_adapter_class

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -18,6 +18,10 @@ class Repository::Github < ::Repository::Git
   after_update :update_remote_url
 
   def self.human_attribute_name(attribute_key_name, *args)
+    # Parent class method replaces attribute name and determines result:
+    # https://github.com/redmine/redmine/blob/5.0.2/app/models/repository/git.rb#L30-L31
+    #
+    # But this class does not need it. So, call grand parent class's.
     Repository.human_attribute_name(attribute_key_name, *args)
   end
 

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -3,6 +3,8 @@
 require_dependency 'repository/git'
 
 class Repository::Github < ::Repository::Git
+  REPOSITORY_URI_REGEXP = %r{\Ahttps://github\.com/(.+)/(.+).git}
+
   has_one :github_credential, foreign_key: :repository_id, dependent: :destroy
   accepts_nested_attributes_for :github_credential
 
@@ -68,6 +70,6 @@ class Repository::Github < ::Repository::Git
   end
 
   def scan_url
-    @owner, @repo = url.to_s.scan(%r{https://github.com/(.+)/(.+).git}).flatten
+    @owner, @repo = url.to_s.scan(REPOSITORY_URI_REGEXP).flatten
   end
 end

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -17,6 +17,15 @@ class Repository::Github < ::Repository::Git
   after_create :bare_clone
   after_update :update_remote_url
 
+  def self.human_attribute_name(attribute_key_name, *args)
+    if attribute_key_name.to_s == 'url'
+      # omit https://github.com/redmine/redmine/blob/5.0.2/app/models/repository/git.rb#L30-L31
+      superclass.superclass.__send__(__method__, attribute_key_name, *args)
+    else
+      super
+    end
+  end
+
   def self.scm_adapter_class
     RedmineGithub::Scm::Adapters::GithubAdapter
   end

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -3,7 +3,7 @@
 require_dependency 'repository/git'
 
 class Repository::Github < ::Repository::Git
-  REPOSITORY_URI_REGEXP = %r{\Ahttps://github\.com/(.+)/(.+).git}
+  REPOSITORY_URI_REGEXP = %r{\Ahttps://github\.com/(.+)/(.+)\.git}
 
   has_one :github_credential, foreign_key: :repository_id, dependent: :destroy
   accepts_nested_attributes_for :github_credential

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -9,7 +9,7 @@ class Repository::Github < ::Repository::Git
   accepts_nested_attributes_for :github_credential
 
   safe_attributes 'access_token', 'webhook_secret'
-  validates_presence_of :url
+  validates :url, presence: true, format: { with: REPOSITORY_URI_REGEXP }
   validates_presence_of :access_token
   validates_presence_of :webhook_secret
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,11 @@ en:
   label_github_webhook_secret: Webhook Secret
   setting_redmine_github_title: Redmine Github Settings
   setting_webhook_use_hostname: Use Redmine hostname in webhook requests
+  text_github_repository_note: "Example: https://github.com/[owner]/[repository name].git"
+  activerecord:
+    errors:
+      models:
+        repository/github:
+          attributes:
+            base:
+              failed_to_create_webhook: Failed to connect to GitHub.com. Please check your Access Token and URL.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,11 @@ ja:
   label_github_webhook_secret: Webhook Secret
   setting_redmine_github_title: Redmine Github プラグイン設定
   setting_webhook_use_hostname: Webhookリクエストでhostnameを使います
+  text_github_repository_note: "例: https://github.com/[owner]/[repository name].git"
+  activerecord:
+    errors:
+      models:
+        repository/github:
+          attributes:
+            base:
+              failed_to_create_webhook: GitHub.comへの接続に失敗しました。アクセストークンとURLを確認してください。

--- a/lib/redmine_github/include/repositories_controller_patch.rb
+++ b/lib/redmine_github/include/repositories_controller_patch.rb
@@ -24,6 +24,8 @@ module RedmineGithub
         }, only: :create
       end
 
+      private
+
       def repository_webhook_url
         use_hostname = ::Setting.plugin_redmine_github['webhook_use_hostname'].to_s
         return redmine_github_webhook_url(repository_id: @repository) unless use_hostname == '1'

--- a/spec/controllers/redmine_github/repositories_controller_spec.rb
+++ b/spec/controllers/redmine_github/repositories_controller_spec.rb
@@ -10,9 +10,6 @@ RSpec.describe RepositoriesController, type: :controller do
 
   before do
     login_as(admin)
-    allow_any_instance_of(RepositoriesController).to receive(:authorize) { true }
-    # interupt Github webhook API POST requests
-    allow_any_instance_of(RedmineGithub::GithubApi::Rest::Client).to receive(:post) { nil }
   end
 
   context 'create repository' do

--- a/spec/controllers/redmine_github/repositories_controller_spec.rb
+++ b/spec/controllers/redmine_github/repositories_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RepositoriesController, type: :controller do
     login_as(admin)
   end
 
-  context 'create repository' do
+  describe '#create' do
     subject(:call) do
       fixed_params = Rails::VERSION::MAJOR < 5 ? params : { params: params }
       post(:create, **fixed_params)
@@ -39,9 +39,11 @@ RSpec.describe RepositoriesController, type: :controller do
       end
     end
 
-    it 'should send webhooks API request' do
-      expect_any_instance_of(RedmineGithub::GithubApi::Rest::Webhook).to receive(:create)
-      expect(call).to redirect_to(settings_project_path(project, tab: :repositories))
+    context 'create repository' do
+      it 'should send webhooks API request' do
+        expect_any_instance_of(RedmineGithub::GithubApi::Rest::Webhook).to receive(:create)
+        expect(call).to redirect_to(settings_project_path(project, tab: :repositories))
+      end
     end
   end
 end

--- a/spec/controllers/redmine_github/repositories_controller_spec.rb
+++ b/spec/controllers/redmine_github/repositories_controller_spec.rb
@@ -25,13 +25,19 @@ RSpec.describe RepositoriesController, type: :controller do
       }
     end
 
+    around do |example|
+      Repository::Github.skip_callback(:create, :after, :bare_clone)
+      begin
+        example.run
+      ensure
+        Repository::Github.set_callback(:create, :after, :bare_clone)
+      end
+    end
+
     it 'should send webhooks API request' do
       expect_any_instance_of(RedmineGithub::GithubApi::Rest::Webhook).to receive(:create)
-      Repository::Github.skip_callback(:create, :after, :bare_clone)
       fixed_params = Rails::VERSION::MAJOR < 5 ? params : { params: params }
       expect(post :create, **fixed_params).to redirect_to(settings_project_path(project, tab: :repositories))
-      # post project_repositories_path(project), params: params
-      Repository::Github.set_callback(:create, :after, :bare_clone)
     end
   end
 end

--- a/spec/controllers/redmine_github/repositories_controller_spec.rb
+++ b/spec/controllers/redmine_github/repositories_controller_spec.rb
@@ -45,5 +45,17 @@ RSpec.describe RepositoriesController, type: :controller do
         expect(call).to redirect_to(settings_project_path(project, tab: :repositories))
       end
     end
+
+    context 'when failed to create webhook on GitHub.com' do
+      it 'should not create Repository record' do
+        unauthorized_response = Net::HTTPResponse.new('1.1', '401', 'Unauthorized')
+        allow_any_instance_of(RedmineGithub::GithubApi::Rest::Client).to(
+          receive(:post).
+            and_raise(RedmineGithub::GithubApi::Rest::Error, unauthorized_response)
+        )
+        expect { call }.not_to(change(Repository, :count))
+        expect(response).to have_http_status(:success)
+      end
+    end
   end
 end

--- a/spec/controllers/redmine_github/repositories_controller_spec.rb
+++ b/spec/controllers/redmine_github/repositories_controller_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe RepositoriesController, type: :controller do
   end
 
   context 'create repository' do
+    subject(:call) do
+      fixed_params = Rails::VERSION::MAJOR < 5 ? params : { params: params }
+      post(:create, **fixed_params)
+    end
+
     let(:params) do
       {
         project_id: project.id,
@@ -36,8 +41,7 @@ RSpec.describe RepositoriesController, type: :controller do
 
     it 'should send webhooks API request' do
       expect_any_instance_of(RedmineGithub::GithubApi::Rest::Webhook).to receive(:create)
-      fixed_params = Rails::VERSION::MAJOR < 5 ? params : { params: params }
-      expect(post :create, **fixed_params).to redirect_to(settings_project_path(project, tab: :repositories))
+      expect(call).to redirect_to(settings_project_path(project, tab: :repositories))
     end
   end
 end


### PR DESCRIPTION
This pull-request includes:

- https://github.com/agileware-jp/redmine_github/pull/50/commits/7458202e3cb5f66686d00f1d183ad6f812112a70 check URL format
    - `Repository::Github` seems to require `https://github.com/[owner]/[repository name].git` format: https://github.com/agileware-jp/redmine_github/blob/c5a358b09b70d1e67b02cabb87c38ae8519e49ca/app/models/repository/github.rb#L71
    - related commits: https://github.com/agileware-jp/redmine_github/pull/50/commits/4521f709735afaf9de7615d58980c7bdf2046057 https://github.com/agileware-jp/redmine_github/pull/50/commits/aea083880546b929c9d74c2a547ab1e0f495de7b
- https://github.com/agileware-jp/redmine_github/pull/50/commits/1ac5ac9d489501876d8e45ea4a125f87847430d4 fix field name of :url on validation message
- https://github.com/agileware-jp/redmine_github/pull/50/commits/a6a902b68aa1c1cacc49945acac7eb5f144e6df3 check GitHub webhook creation
    - related refactors: https://github.com/agileware-jp/redmine_github/pull/50/commits/432b41fd927dcc1dd486a8c6c11294406ed16b5d https://github.com/agileware-jp/redmine_github/pull/50/commits/da36343808f06289757079b58c5719437360c0e2