### PR TITLE
Use graphql.gem < 2.1, Redmine 5.1 CI Check & Update redmine-plugin-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  redmine-plugin: agileware-jp/redmine-plugin@3.1.0
+  redmine-plugin: agileware-jp/redmine-plugin@3.5.0
   rubocop:
     executors:
       rubocop-executor:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 gem 'graphql-client'
 
 # https://github.com/github/graphql-client/issues/310#issuecomment-1709045007

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,4 @@
 gem 'graphql-client'
+
+# https://github.com/github/graphql-client/issues/310#issuecomment-1709045007
+gem 'graphql', '< 2.1'

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -13,4 +13,5 @@ group :test do
   gem 'database_cleaner'
   gem 'rspec_junit_formatter'
   gem 'webmock'
+  dependencies.reject! { |i| i.name == 'nokogiri' } # Ensure Nokogiri have new version
 end


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/pull/4577 removes `GraphQL::StaticValidation::TypeStack`. But graphql-client.gem uses it. So `NameError` is raised on https://github.com/github/graphql-client/blob/v0.18.0/lib/graphql/client/document_types.rb#L24 .

Same problem is here: https://github.com/github/graphql-client/issues/310 .

This pull-request includes ad-hoc fix.
